### PR TITLE
Prevent goroutine leakage after test server stop

### DIFF
--- a/server.go
+++ b/server.go
@@ -147,6 +147,12 @@ func (sts *Server) GetWSURL() string {
 // Stop stops the test server
 func (sts *Server) Stop() {
 	sts.server.Close()
+
+	// The outstanding sent channels need to be closed
+	// to prevent the listening goroutines from leaking.
+	for _, channels := range masterHub.serverChannels {
+		close(channels.sent)
+	}
 }
 
 // Start starts the test server


### PR DESCRIPTION
While using this test package it appeared (via the use of https://github.com/fortytw2/leaktest) that the test server was leaking goroutines after stopping. This can be prevented by explicitely closing the channels on which the listening goroutines are blocked.